### PR TITLE
Sep 27 changes

### DIFF
--- a/lab1/simplesim-3.0d-ece552f-assign1/mbq1.c
+++ b/lab1/simplesim-3.0d-ece552f-assign1/mbq1.c
@@ -19,7 +19,7 @@ int main() {
 	/* initialization */
 	int N = 10000000; /* 10,000,000 loop iterations */
 	/* register keyword tells compiler to use registers */
-	register int i = 0; /* iteratore */
+	register int i = 0; /* iterator */
 
 	register int A = 0, B = 0, C = 0;
 	register int *D;

--- a/lab1/simplesim-3.0d-ece552f-assign1/sim-safe.c
+++ b/lab1/simplesim-3.0d-ece552f-assign1/sim-safe.c
@@ -510,17 +510,12 @@ sim_main(void)
 
 /* find if current instr requires register ready delays */
 /* q1 */
-if (
-  // these flags for q1 maybe not necessary --- try removing these
-  ((MD_OP_FLAGS(op) & F_MEM) && (MD_OP_FLAGS(op) & F_LOAD)) ||
-  (MD_OP_FLAGS(op) & F_ICOMP)
-) {
-  /* if instruction is a load or int computation (add, sub, etc.)
-      need to stall for 2 cycles (2 stages between ID and WB stages) */
-  // on next instr, sim_num_insn will increment and the 'delay' will be 2 cycles
-  if(r_out[0] != DNA) reg_ready_q1[r_out[0]] = sim_num_insn + 3; 
-  if(r_out[1] != DNA) reg_ready_q1[r_out[1]] = sim_num_insn + 3;
-}
+/* if instruction has target registers
+    need to stall for 2 cycles (2 stages between ID and WB stages) */
+// on next instr, sim_num_insn will increment and the 'delay' will be 2 cycles
+if(r_out[0] != DNA) reg_ready_q1[r_out[0]] = sim_num_insn + 3; 
+if(r_out[1] != DNA) reg_ready_q1[r_out[1]] = sim_num_insn + 3;
+
 /* don't need to encode 1 cycle stall for q1
     since 1 cycle stall only occurs if dependent
     instr is 2 instrs away */

--- a/lab1/simplesim-3.0d-ece552f-assign1/sim-safe.c
+++ b/lab1/simplesim-3.0d-ece552f-assign1/sim-safe.c
@@ -467,7 +467,7 @@ sim_main(void)
     if (r_in[max_delay_i] != DNA && delay > 0) { /* if delay >= 0 then we have a stall */
       /* skip stores b/c they are bypassed (WM bypass) */
       // check if I2 has delay for store instrs
-      store_delay_of_i2 = reg_ready_q2[r_in[1]] - sim_num_insn;
+      int store_delay_of_i2 = reg_ready_q2[r_in[1]] - sim_num_insn;
       if (!(
         (MD_OP_FLAGS(op) & F_MEM) && (MD_OP_FLAGS(op) & F_STORE)
       )) {


### PR DESCRIPTION
mbq1.c: fixed 'iteratore' to 'iterator' in comment

sim-safe.c: q1) removed flags, should check all instructions for data hazards; q2) check i2 operand for store instrs since it is address and is needed at start of X1